### PR TITLE
Handle spaces in directory paths

### DIFF
--- a/bin/scout
+++ b/bin/scout
@@ -7,4 +7,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-$DIR/../node_modules/phantomjs/bin/phantomjs $DIR/../src/index.js $@
+"$DIR"/../node_modules/phantomjs/bin/phantomjs "$DIR"/../src/index.js $@


### PR DESCRIPTION
Hello there,
I notice something :if you have spaces in directory paths (eg : c:/Program Files), scout can't be executed.

So if you use "$DIR" instead of $DIR, it will be handle these.

To test on Unix environments
